### PR TITLE
Ignore StyleSheets that are destructured

### DIFF
--- a/analyzeFile.js
+++ b/analyzeFile.js
@@ -53,6 +53,9 @@ module.exports = (file) => {
   })
 
   const sheets = styleSheets.map(({id, keys, keyNames, binding}) => {
+    if (!binding) {
+      return null
+    }
     const warnings = []
     const referenced = binding.referencePaths.map(ref => {
       if (ref.parent.type !== 'MemberExpression') {
@@ -87,7 +90,7 @@ module.exports = (file) => {
     }))
 
     return {loc: id.loc, code: locLines(lines, id.loc), warnings, unused, missing}
-  })
+  }).filter(x => x)
   return {sheets, lines}
 }
 


### PR DESCRIPTION
There was a StyleSheet that was immediately destructured, like so:

```
const {dimensions} = StyleSheet.create({
    dimensions: {
        height: ...,
        width: ....,
    },
});
```

This caused stylecleanup to crash as it has no valid binding for the file.

Test Plan:
I tested my change against a file that had this syntax in it and it didn't crash (it also didn't analyze the StyleSheet, but I think that's ok since this is a pretty non-traditional situation).